### PR TITLE
Fix tutorial navigation links

### DIFF
--- a/tutorial/step_1_first_logic/readme.md
+++ b/tutorial/step_1_first_logic/readme.md
@@ -69,4 +69,4 @@ That wraps up our first Morphir model!
 
 
 
-[Home](../../readme.md) | [Prev](../../install.md) | [Next](step_2_business_language/readme.md)
+[Home](../../readme.md) | [Prev](../../install.md) | [Next](../step_2_business_language/readme.md)

--- a/tutorial/step_2_business_language/readme.md
+++ b/tutorial/step_2_business_language/readme.md
@@ -7,4 +7,4 @@ An important part of writing business applications is ensuring that the business
 sharing the same language to describe the application.  
 
 
-[Home](../../readme.md) | [Prev](../step_1_first_logic/readme.md) | [Next](step_3_catching_bugs/readme.md)
+[Home](../../readme.md) | [Prev](../step_1_first_logic/readme.md) | [Next](../step_3_catching_bugs/readme.md)


### PR DESCRIPTION
I read contributing guide about DCO but there are no DCO templates at the paths mentioned.
Anyway changes are trivial, please feel free to close this PR and just update files manually :-)